### PR TITLE
Changed internal flag to avoid warnings in PHPStorm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this library will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Changed `@internal` description of class CodeIgniter4 to avoid warnings in phpstorm
+
 ## [v1.6.0](https://github.com/CodeIgniter/coding-standard/compare/v1.5.0...v1.6.0) - 2022-10-15
 
 - Bump php-cs-fixer version to v3.12 minimum

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this library will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.6.1](https://github.com/CodeIgniter/coding-standard/compare/v1.6.0...v1.6.1) - 2022-10-20
 
 - Changed `@internal` description of class CodeIgniter4 to avoid warnings in phpstorm
 

--- a/src/CodeIgniter4.php
+++ b/src/CodeIgniter4.php
@@ -18,7 +18,7 @@ use Nexus\CsConfig\Ruleset\AbstractRuleset;
 /**
  * Defines the ruleset used for the CodeIgniter4 organization.
  *
- * @internal
+ * {@internal Use of this class is not covered by the backward compatibility promise for CodeIgniter4.}
  */
 final class CodeIgniter4 extends AbstractRuleset
 {


### PR DESCRIPTION
Closes #6 

Changed the syntax of the `@internal` comment to avoid getting messages in PHPStorm 2022.3.